### PR TITLE
undefined error if scanner is closed within scanDelay after a success…

### DIFF
--- a/src/app/modules/zxing-scanner/browser-code-reader.ts
+++ b/src/app/modules/zxing-scanner/browser-code-reader.ts
@@ -184,7 +184,7 @@ export class BrowserCodeReader {
 
         try {
 
-            const result = this.readerDecode(binaryBitmap);
+            const result = this.reader.decode(binaryBitmap);
 
             callbackFn(result);
 
@@ -214,15 +214,6 @@ export class BrowserCodeReader {
                 this.decodeWithDelay(callbackFn);
             }
         }
-    }
-
-    /**
-     * Alias for this.reader.decode
-     *
-     * @param binaryBitmap
-     */
-    protected readerDecode(binaryBitmap: BinaryBitmap): Result {
-        return this.reader.decode(binaryBitmap);
     }
 
     /**

--- a/src/app/modules/zxing-scanner/browser-code-reader.ts
+++ b/src/app/modules/zxing-scanner/browser-code-reader.ts
@@ -189,7 +189,7 @@ export class BrowserCodeReader {
             callbackFn(result);
 
             if (!once && !!this.stream) {
-                setTimeout(() => this.decodeWithDelay(callbackFn), this.timeBetweenScans);
+                this.decodeWithDelay(callbackFn);
             }
 
         } catch (re) {


### PR DESCRIPTION
…ful QR scan

See the following issue for details: https://github.com/zxing-js/ngx-scanner/issues/71