### PR TITLE
Resolve issue where 2 timer are set

### DIFF
--- a/src/app/modules/zxing-scanner/browser-code-reader.ts
+++ b/src/app/modules/zxing-scanner/browser-code-reader.ts
@@ -246,6 +246,7 @@ export class BrowserCodeReader {
      * @param callbackFn
      */
     private decodeWithDelay(callbackFn: (result: Result) => any): void {
+        window.clearTimeout(this.timeoutHandler);
         this.timeoutHandler = window.setTimeout(this.decode.bind(this, callbackFn), this.timeBetweenScans);
     }
 


### PR DESCRIPTION
I've run into an issue where the component throws an error:
```
TypeError: Cannot read property 'naturalWidth' of undefined
    at BrowserQRCodeReader.BrowserCodeReader.prepareCaptureCanvas (zxing-ngx-scanner.js:167)
    at BrowserQRCodeReader.BrowserCodeReader.createBinaryBitmap (zxing-ngx-scanner.js:146)
    at BrowserQRCodeReader.BrowserCodeReader.decode (zxing-ngx-scanner.js:122)
```

Basically it occurs when creating and destroying the component twice in a row, I have the feeling that it's caused by a race condition allowing the code to create two timers, and only cleaning the first.

The method decodeFromInputVideoDevice is called twice, once after the component initializes, the second time with ngOnChange when the device changes. Because of the asynchronous nature of             `navigator.mediaDevices.getUserMedia(constraints)` the reset is called twice, without the getUserMedia actually resolving in between, thus creating 2 timeouts, of which the first one is lost forever since the reference is gone.