### PR TITLE
Remove private field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@zxing/ngx-scanner",
   "version": "1.0.0",
-  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/zxing-js/ngx-scanner"


### PR DESCRIPTION
If private is set to true, the some informations like licence are omit on push.

See: https://www.npmjs.com/package/@zxing/ngx-scanner - Licence: none