### PR TITLE
Update npmpublish.yml

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -70,6 +70,8 @@ jobs:
   publish-gpr:
     needs: build
     runs-on: ubuntu-latest
+    env:
+      REPOSITORY_NAME: ngx-scanner
     steps:
 
       - name: Download build artifacts
@@ -79,10 +81,6 @@ jobs:
 
       - name: Install JQ for JSON handling
         run: sudo apt-get install jq
-
-      - name: Get repository name
-        run: echo ::set-env name=REPOSITORY_NAME::$(echo "$GITHUB_REPOSITORY" | awk -F / '{print $2}' | sed -e "s/:refs//")
-        shell: bash
 
       - name: Rename NPM package
         run: |


### PR DESCRIPTION
@werthdavid Thanks for publishing to NPM.

This is to fix publishing to github package registry. (hopefully)
I don't think it's critical, though. I don't know who's installing it from github.

Also I don't know if there is a reason to get the repo name dynamically. If there is, we can look at a new way to grab it dynamically.
The `::set-env` way is apparently outdated now.