### PR TITLE
Update npmpublish.yml

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           name: pack-artifact
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
@@ -93,7 +93,7 @@ jobs:
           rm temp.json
 
       # Setup .npmrc file to publish to GitHub Packages
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: '12.x'
           registry-url: 'https://npm.pkg.github.com'


### PR DESCRIPTION
The gpr step was somehow hitting npmjs.org instead of npm.pkg.github.com

I noticed the `setup-node` action deprecated `v1` a while ago so might as well bump it before trying anything else.

I think you might be able to manually trigger this action instead of having to make a new release every time.