### PR TITLE
Changed target of demo and added catch() to setDevice() call

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -74,7 +74,10 @@
             "buildOptimizer": false,
             "sourceMap": true,
             "optimization": false,
-            "namedChunks": true
+            "namedChunks": true,
+            "allowedCommonJsDependencies": [
+                "@zxing/library"
+            ]
           },
           "configurations": {
             "production": {

--- a/projects/zxing-scanner/package.json
+++ b/projects/zxing-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zxing/ngx-scanner",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "High-performance Angular 8 barcode scanner component based on ZXing.",
   "homepage": "https://github.com/zxing-js/ngx-scanner#readme",
   "private": false,

--- a/projects/zxing-scanner/src/lib/browser-multi-format-continuous-reader.ts
+++ b/projects/zxing-scanner/src/lib/browser-multi-format-continuous-reader.ts
@@ -63,7 +63,7 @@ export class BrowserMultiFormatContinuousReader extends BrowserMultiFormatReader
 
         // probably fatal error
         scan$.error(error);
-        this.scannerControls.stop();
+        this.scannerControls?.stop();
         this.scannerControls = undefined;
         return;
       });

--- a/projects/zxing-scanner/src/lib/zxing-scanner.component.ts
+++ b/projects/zxing-scanner/src/lib/zxing-scanner.component.ts
@@ -221,7 +221,11 @@ export class ZXingScannerComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.setDevice(device);
+    this.setDevice(device).catch(
+        (error: any) => {
+            console.error('@zxing/ngx-scanner', 'Error while setting the device.', error);
+        }
+    );
   }
 
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es5",
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
Hello there,

when using the ngx-scanner I've recently had the problem, that on disposing and changing the device, the setOptions error described in [this issue](https://github.com/zxing-js/ngx-scanner/issues/297) would occur.

I tried to fix at least the displayed message by setting a catch on the async function in the device setter.
I've also changed the target version from es2015 to es5 to fix an error about different version targets between the demo and the other projects.