### PR TITLE
[#425] - Bugfix - v3.2.0: Camera does not get freed after route change

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@angular/platform-browser-dynamic": "12.0.4",
     "@angular/router": "12.0.4",
     "@angular/service-worker": "12.0.4",
-    "@zxing/browser": "0.0.9",
+    "@zxing/browser": "0.0.10",
     "@zxing/library": "0.18.3",
     "rxjs": "^6.6.3",
     "tslib": "^2.2.0"

--- a/projects/zxing-scanner/src/lib/zxing-scanner.component.ts
+++ b/projects/zxing-scanner/src/lib/zxing-scanner.component.ts
@@ -341,6 +341,7 @@ export class ZXingScannerComponent implements OnInit, OnDestroy {
 
     if (!this._enabled) {
       this.reset();
+      BrowserMultiFormatContinuousReader.releaseAllStreams();
     } else {
       if (this.device) {
         this.scanFromDevice(this.device.deviceId);
@@ -539,6 +540,7 @@ export class ZXingScannerComponent implements OnInit, OnDestroy {
    */
   ngOnDestroy(): void {
     this.reset();
+    BrowserMultiFormatContinuousReader.releaseAllStreams();
   }
 
   /**


### PR DESCRIPTION
[#425] - Bugfix - v3.2.0: Camera does not get freed after route change
* Upgraded @zxing/browser version
* Cleaning of all used streams when ngOnDestroy() is called and when scanner is disabled.

**Important:** Merge and release @zxing/browser changes first!
https://github.com/zxing-js/browser/pull/73

Correct browser version if necessary.