### PR TITLE
Moved codeReader reset up in reset method to fix #297 setOptions error

### DIFF
--- a/projects/zxing-scanner/package.json
+++ b/projects/zxing-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zxing/ngx-scanner",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "High-performance Angular barcode scanner component based on ZXing.",
   "homepage": "https://github.com/zxing-js/ngx-scanner#readme",
   "private": false,

--- a/projects/zxing-scanner/src/lib/zxing-scanner.component.ts
+++ b/projects/zxing-scanner/src/lib/zxing-scanner.component.ts
@@ -829,11 +829,13 @@ export class ZXingScannerComponent implements OnInit, OnDestroy {
       return;
     }
 
+    // clearing codeReader first to prevent setOptions error appearing in several Chromium versions
+    this._codeReader = undefined;
+
     const device = this._device;
     // do not set this.device inside this method, it would create a recursive loop
     this.device = undefined;
 
-    this._codeReader = undefined;
 
     return device;
   }


### PR DESCRIPTION
Fix to prevent scanner setOptions error on several Chromium versions during the component onDestroy cycle. Related to the issue #297 