### PR TITLE
prevent placeholder icon appear on android

### DIFF
--- a/projects/zxing-scanner/src/lib/zxing-scanner.component.html
+++ b/projects/zxing-scanner/src/lib/zxing-scanner.component.html
@@ -1,4 +1,4 @@
-<video #preview [style.object-fit]="previewFitMode">
+<video #preview [style.object-fit]="previewFitMode" poster="noposter">
   <p>
     Your browser does not support this feature, please try to upgrade it.
   </p>


### PR DESCRIPTION
Remove android placeholder image when video tag not ready yet.

fixes referring to stackoverflow: https://stackoverflow.com/a/57506234

<img width="244" alt="android placeholder default poster" src="https://user-images.githubusercontent.com/27732258/235572505-b854fa64-2819-4676-a0cf-81fbde134342.png">

