### PR TITLE
allows the poster attribute of the html video tag to be bindable.

### DIFF
--- a/projects/zxing-scanner/src/lib/zxing-scanner.component.html
+++ b/projects/zxing-scanner/src/lib/zxing-scanner.component.html
@@ -1,4 +1,4 @@
-<video #preview [style.object-fit]="previewFitMode" poster="noposter">
+<video #preview [style.object-fit]="previewFitMode" [poster]="poster">
   <p>
     Your browser does not support this feature, please try to upgrade it.
   </p>

--- a/projects/zxing-scanner/src/lib/zxing-scanner.component.ts
+++ b/projects/zxing-scanner/src/lib/zxing-scanner.component.ts
@@ -123,6 +123,12 @@ export class ZXingScannerComponent implements OnInit, OnDestroy {
   previewFitMode: 'fill' | 'contain' | 'cover' | 'scale-down' | 'none' = 'cover';
 
   /**
+   * Url of the HTML video poster
+   */
+  @Input()
+  poster: string = '';
+
+  /**
    * Emits events when the torch compatibility is changed.
    */
   @Output()
@@ -757,7 +763,7 @@ export class ZXingScannerComponent implements OnInit, OnDestroy {
     if (!this._codeReader) {
       const options = {
         delayBetweenScanAttempts: this.timeBetweenScans,
-        delayBetweenScanSuccess: this.delayBetweenScanSuccess,
+        delayBetweenScanSuccess: this.delayBetweenScanSuccess
       };
       this._codeReader = new BrowserMultiFormatContinuousReader(this.hints, options);
     }
@@ -784,7 +790,8 @@ export class ZXingScannerComponent implements OnInit, OnDestroy {
 
     const next = (x: ResultAndError) => this._onDecodeResult(x.result, x.error);
     const error = (err: any) => this._onDecodeError(err);
-    const complete = () => { };
+    const complete = () => {
+    };
 
     this._scanSubscription = scanStream.subscribe(next, error, complete);
 


### PR DESCRIPTION
This resolves the 404 noposter issue when using this library.

Currently without a file called 'noposter' at the root of the server an application using this library will make a 404 http call. this allows users to specify a poster or opt to not using one whatsoever. Either way the 404 is resolved.