### PR TITLE
Added abort error check

### DIFF
--- a/projects/zxing-scanner/src/lib/zxing-scanner.component.ts
+++ b/projects/zxing-scanner/src/lib/zxing-scanner.component.ts
@@ -732,7 +732,15 @@ export class ZXingScannerComponent implements OnInit, OnDestroy {
         // tells the listener about the error
         this.camerasNotFound.next(err);
         break;
-
+      case 'AbortError':
+        console.warn('@zxing/ngx-scanner', 'It seems that the required permissions have been granted, but something else failed', err);
+        // permissions claimed
+        permission = true;
+        // can't check devices
+        this.hasDevices.next(null);
+        // tells the listener about the error
+        this.camerasNotFound.next(err);
+        break;
       default:
         console.warn('@zxing/ngx-scanner', 'I was not able to define if I have permissions for camera or not.', err);
         // unknown


### PR DESCRIPTION
As firefox seems to have issues with accessing the camera, throwing the abort error exception, I added a check in the scanner, allowing the proper display of this exception.

I couldn't fix the exception by itself, as it gets thrown when both, the device and the browser granted the permissions to the website, but the hardware failed creating a video stream.